### PR TITLE
add snippets for mobile platform projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [0.2.0] - 2021-04-19
+### Added
+- Mobile platform snippets
+
 ## [0.1.0] - 2020-05-29
 ### Fixed
 - Extension Logo for VSCode marketplace :)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "loadsmart-react-native",
   "displayName": "Loadsmart React Native Extension Pack",
   "description": "Set of plugins to start developing React Native applications at Loadsmart",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "publisher": "Loadsmart",
   "preview": true,
   "repository": {
@@ -16,6 +16,18 @@
   "categories": [
     "Extension Packs"
   ],
+  "contributes": {
+    "snippets": [
+      {
+        "language": "typescriptreact",
+        "path": "./typescriptreact.snippets.json"
+      },
+      {
+        "language": "typescript",
+        "path": "./typescript.snippets.json"
+      }
+    ]
+  },
   "extensionPack": [
     "christian-kohler.npm-intellisense",
     "esbenp.prettier-vscode",

--- a/typescript.snippets.json
+++ b/typescript.snippets.json
@@ -1,0 +1,17 @@
+{
+  "Mobile platform use case": {
+    "prefix": "mpuc",
+    "body": [
+      "type ${TM_FILENAME/(.*?)\\..+/${1}/}Deps = {",
+      "}",
+      "",
+      "export const ${TM_FILENAME/(.*?)\\..+/${1}/}Factory = (dependencies: ${TM_FILENAME/(.*?)\\..+/${1}/}Deps) => async () => {",
+      "",
+      "}",
+      "",
+      "export const ${TM_FILENAME/(.*?)\\..+/${1}/} = () => {",
+      "}"
+    ],
+    "description": "Boilerplate to use case"
+  }
+}

--- a/typescriptreact.snippets.json
+++ b/typescriptreact.snippets.json
@@ -1,0 +1,55 @@
+{
+	"Mobile platform component test": {
+		"prefix": "mpct",
+		"body": [
+			"import React from 'react'",
+			"",
+			"import { renderWithProviders } from '@test/renderWithProviders'",
+			"",
+			"import ${TM_FILENAME/(.*?)\\..+/${1}/} from './${TM_FILENAME/(.*?)\\..+/${1}/}'",
+			"",
+			"const defaultProps = {${1}}",
+			"",
+			"const setup = (props = {}) => renderWithProviders(<${TM_FILENAME/(.*?)\\..+/${1}/} {...defaultProps} {...props} />)",
+			"",
+			"describe('${TM_FILENAME/(.*?)\\..+/${1}/}', () => {",
+			"\tit('should ${2: do something}', () => {",
+			"\t\tconst {${3}} = setup()",
+			"\t\t${4}",
+			"\t})",
+			"})"
+		],
+		"description": "Boilerplate to test React component"
+	},
+	"Test unit": {
+		"prefix": "mpit",
+		"body": [
+			"it('should ${1:do something} ', () => {",
+			"\tconst {${2}} = setup()",
+			"\t${3}",
+			"})"
+		],
+		"description": "Boilerplate to unit test"
+	},
+	"Mobile platform component": {
+		"prefix": "mpc",
+		"body": [
+			"import React from 'react'",
+			"",
+			"import styled from 'styled-components/native'",
+			"",
+			"const Container = styled.View``",
+			"",
+			"const ${TM_FILENAME_BASE} = () => {",
+			"\treturn (",
+			"\t\t<Container>",
+			"\t\t\t${1}",
+			"\t\t</Container>",
+			"\t)",
+			"}",
+			"",
+			"export default ${TM_FILENAME_BASE}"
+		],
+		"description": "Boilerplate to React components"
+	}
+}


### PR DESCRIPTION
## Motivation
This is a proposal to have snippets with some common boilerplate on the mobile platform projects. 

## Snippets

### Mobile platform use case (mpuc)
https://user-images.githubusercontent.com/24190696/115023139-c016cc00-9e94-11eb-86b4-b655f88593eb.mov 

### Mobile platform component test (mpct)
https://user-images.githubusercontent.com/24190696/115023320-02d8a400-9e95-11eb-954b-bd5ce0d75baa.mov

### Mobile platform test unit (mpit) 
https://user-images.githubusercontent.com/24190696/115023430-2ac80780-9e95-11eb-93f4-5b7781e4cfa1.mov

### Mobile platform component (mpc)
https://user-images.githubusercontent.com/24190696/115023475-3ca9aa80-9e95-11eb-848b-689c5dc2d5a7.mov




